### PR TITLE
Add optional "None" currency setting for numeric-only

### DIFF
--- a/src/currency-display/display.vue
+++ b/src/currency-display/display.vue
@@ -78,6 +78,16 @@ const locale = computed(() => localeSettings.value.locale);
  */
 const formattedValue = computed(() => {
 	if (props.value === null || props.value === undefined) return '';
+
+	if (!configuredCurrency) {
+		return new Intl.NumberFormat(locale.value, {
+			style: 'decimal',
+			useGrouping: true,
+			minimumFractionDigits: scale,
+			maximumFractionDigits: scale,
+		}).format(Number(props.value));
+	}
+
 	return new Intl.NumberFormat(locale.value, {
 		style: 'currency',
 		currency: configuredCurrency,

--- a/src/currency-interface/interface.vue
+++ b/src/currency-interface/interface.vue
@@ -95,10 +95,13 @@ const decimalSeparator = computed(() => {
  * @returns {string} A string representing the currency prefix.
  */
 const prefix = computed(() => {
+	const currency = props.currency === undefined ? 'USD' : props.currency;
+	if (!currency) return null;
+
 	return `${Intl
 		.NumberFormat(locale.value, {
 			style: 'currency',
-			currency: props?.currency || 'USD',
+			currency: currency,
 			currencyDisplay: 'symbol',
 		})
 		.formatToParts(0)

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,7 @@ export const DEFAULT_CURRENCY = 'USD';
 
 export const DEFAULT_CURRENCIES = [
 	// Most common currencies first
+	{ text: 'None', value: null },
 	{ text: 'Euro (€)', value: 'EUR' },
 	{ text: 'United States Dollar ($)', value: 'USD' },
 	{ text: 'British Pound (£)', value: 'GBP' },


### PR DESCRIPTION
## Summary
- Added "None" as the first option in the currency selector dropdown
- Modified interface to hide currency prefix when no currency is selected
- Updated display component to show formatted numbers without currency symbols when currency is null

## Testing
- [x] Verified "None" option appears in currency selector
- [x] Confirmed no prefix shows when "None" is selected
- [x] Validated number formatting with proper grouping/decimals
- [x] Ensured existing currency options still work correctly


Fixes https://github.com/joggienl/directus-extension-simple-currency-field/issues/3
