### PR TITLE
Resolve useStores Injection Error

### DIFF
--- a/src/currency-display/display.vue
+++ b/src/currency-display/display.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { getFieldPrecisionAndScale, getLocaleSettings } from '../shared/utils.js';
+import { getFieldPrecisionAndScale, useLocaleSettings } from '../shared/utils.js';
 
 //
 // Setup and types
@@ -41,24 +41,9 @@ const [, numericScale] = getFieldPrecisionAndScale(
 );
 const scale = numericScale ?? 2;
 
-/**
- * @computed
- * Reactive wrapper for the current locale configuration.
- * Updates automatically when locale settings change.
- *
- * @returns {LocaleSettings} Current locale settings object
- */
-const localeSettings = computed(() =>
-	getLocaleSettings(),
-);
+const { locale } = useLocaleSettings();
 
-/**
- * @computed
- * Current locale identifier used for formatting.
- *
- * @returns {string} The current locale string
- */
-const locale = computed(() => localeSettings.value.locale);
+
 
 /**
  * @computed

--- a/src/currency-interface/interface.vue
+++ b/src/currency-interface/interface.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { getFieldPrecisionAndScale, getLocaleSettings } from '../shared/utils.js';
+import { getFieldPrecisionAndScale, useLocaleSettings } from '../shared/utils.js';
 
 //
 // Setup and types
@@ -46,27 +46,12 @@ const emit = defineEmits<{
 }>();
 
 const rawInput = ref('');
-const [,numericScale] = getFieldPrecisionAndScale(props.collection, props.field);
+const [, numericScale] = getFieldPrecisionAndScale(props.collection, props.field);
 const scale = numericScale ?? 0;
 
-/**
- * @computed
- * Reactive wrapper for the current locale configuration.
- * Updates automatically when locale settings change.
- *
- * @returns {LocaleSettings} Current locale settings object
- */
-const localeSettings = computed(() =>
-	getLocaleSettings(),
-);
+const { locale } = useLocaleSettings();
 
-/**
- * @computed
- * Current locale identifier used for formatting.
- *
- * @returns {string} The current locale string
- */
-const locale = computed(() => localeSettings.value.locale);
+
 
 /**
  * @computed
@@ -123,7 +108,7 @@ function cleanValueString(value: string) {
 		.replaceAll(/[^\d.,-]/g, '')
 		// Then handle the minus sign specifically
 		.replaceAll(/(?!^)-/g, '')
-	;
+		;
 }
 
 /**
@@ -181,10 +166,10 @@ function formatNumber(value: string, options: FormatNumberOptions) {
 
 	return !Number.isNaN(number)
 		? new Intl.NumberFormat(locale.value, {
-				minimumFractionDigits: scale,
-				maximumFractionDigits: scale,
-				useGrouping,
-			}).format(number)
+			minimumFractionDigits: scale,
+			maximumFractionDigits: scale,
+			useGrouping,
+		}).format(number)
 		: '';
 }
 
@@ -316,15 +301,7 @@ function handlePaste(event: ClipboardEvent) {
 </script>
 
 <template>
-	<v-input
-		:model-value="inputValue"
-		type="text"
-		:prefix="prefix"
-		inputmode="decimal"
-		:pattern="`^-?\\d*${decimalSeparator}?\\d*$`"
-		@input="handleInput"
-		@paste="handlePaste"
-		@blur="() => handleFocusOrBlurEvent(false)"
-		@focus="() => handleFocusOrBlurEvent(true)"
-	/>
+	<v-input :model-value="inputValue" type="text" :prefix="prefix" inputmode="decimal"
+		:pattern="`^-?\\d*${decimalSeparator}?\\d*$`" @input="handleInput" @paste="handlePaste"
+		@blur="() => handleFocusOrBlurEvent(false)" @focus="() => handleFocusOrBlurEvent(true)" />
 </template>

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,4 +1,5 @@
 import { useStores } from '@directus/extensions-sdk';
+import { computed } from 'vue';
 
 /** Represents a language/locale identifier (e.g., 'en-US', 'fr-FR') */
 type Locale = string;
@@ -11,20 +12,21 @@ interface LocaleSettings {
 /**
  * Retrieves the locale settings based on user preferences and system defaults.
  *
- * @returns {LocaleSettings} An object containing the resolved locale,
+ * @returns {object} An object containing the resolved locale validation,
  * prioritizing user language settings, then system defaults, falling back to 'en-US'.
  */
-export function getLocaleSettings(): LocaleSettings {
+export function useLocaleSettings() {
 	const { useUserStore, useSettingsStore } = useStores();
 	const userStore = useUserStore();
 	const settingsStore = useSettingsStore();
 
-	return {
-		locale:
-			userStore.currentUser?.language
+	const locale = computed(() => {
+		return userStore.currentUser?.language
 			|| settingsStore.settings?.default_language
-			|| 'en-US',
-	};
+			|| 'en-US';
+	});
+
+	return { locale };
 }
 
 /** Represents the precision of a numeric field (total number of digits). Null if not specified */


### PR DESCRIPTION
This PR fixes a runtime error where the extension would crash with `useStores` The stores could not be found.

The `getLocaleSettings` utility was calling `useStores()` inside a function that was being used within a computed property. Because computed properties are evaluated lazily, `useStores()` was attempting to inject dependencies after the component's strict `setup()` phase had already completed, causing the injection to fail.


Fixes: https://github.com/joggienl/directus-extension-simple-currency-field/issues/2